### PR TITLE
Implement GraphQL

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,4 +1,5 @@
 DEVELOPMENT=true
-MONGODB_URI=mongodb://localhost:27017/web-crawler-test
+MONGODB_URI=mongodb://localhost:27017
 PORT=3000
+GRAPHQL_PORT=9000
 JWT_SECRET=vk5GuQWMW1kF

--- a/.env.dev
+++ b/.env.dev
@@ -1,5 +1,5 @@
 DEVELOPMENT=true
-MONGODB_URI=mongodb://localhost:27017
+MONGODB_URI=mongodb://localhost:27017/crawlerDev
 PORT=3000
 GRAPHQL_PORT=9000
 JWT_SECRET=vk5GuQWMW1kF

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,12 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
+        "@apollo/server": "^4.10.0",
+        "@types/graphql": "^14.5.0",
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.6",
         "express": "^4.18.2",
+        "graphql": "^16.8.1",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.1.2",
         "validator": "^13.11.0"
@@ -43,6 +46,247 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apollo/cache-control-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@apollo/cache-control-types/-/cache-control-types-1.0.3.tgz",
+      "integrity": "sha512-F17/vCp7QVwom9eG7ToauIKdAxpSoadsJnqIfyryLFSkLSOEqu+eC5Z3N8OXcUVStuOMcNHlyraRsA6rRICu4g==",
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/protobufjs": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.7.tgz",
+      "integrity": "sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "apollo-pbjs": "bin/pbjs",
+        "apollo-pbts": "bin/pbts"
+      }
+    },
+    "node_modules/@apollo/server": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.10.0.tgz",
+      "integrity": "sha512-pLx//lZ/pvUfWL9G8Np8+y3ujc0pYc8U7dwD6ztt9FAw8NmCPzPaDzlXLBAjGU6WnkqVBOnz8b3dOwRNjLYSUA==",
+      "dependencies": {
+        "@apollo/cache-control-types": "^1.0.3",
+        "@apollo/server-gateway-interface": "^1.1.1",
+        "@apollo/usage-reporting-protobuf": "^4.1.1",
+        "@apollo/utils.createhash": "^2.0.0",
+        "@apollo/utils.fetcher": "^2.0.0",
+        "@apollo/utils.isnodelike": "^2.0.0",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
+        "@apollo/utils.logger": "^2.0.0",
+        "@apollo/utils.usagereporting": "^2.1.0",
+        "@apollo/utils.withrequired": "^2.0.0",
+        "@graphql-tools/schema": "^9.0.0",
+        "@josephg/resolvable": "^1.0.0",
+        "@types/express": "^4.17.13",
+        "@types/express-serve-static-core": "^4.17.30",
+        "@types/node-fetch": "^2.6.1",
+        "async-retry": "^1.2.1",
+        "cors": "^2.8.5",
+        "express": "^4.17.1",
+        "loglevel": "^1.6.8",
+        "lru-cache": "^7.10.1",
+        "negotiator": "^0.6.3",
+        "node-abort-controller": "^3.1.1",
+        "node-fetch": "^2.6.7",
+        "uuid": "^9.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16.0"
+      },
+      "peerDependencies": {
+        "graphql": "^16.6.0"
+      }
+    },
+    "node_modules/@apollo/server-gateway-interface": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.1.1.tgz",
+      "integrity": "sha512-pGwCl/po6+rxRmDMFgozKQo2pbsSwE91TpsDBAOgf74CRDPXHHtM88wbwjab0wMMZh95QfR45GGyDIdhY24bkQ==",
+      "dependencies": {
+        "@apollo/usage-reporting-protobuf": "^4.1.1",
+        "@apollo/utils.fetcher": "^2.0.0",
+        "@apollo/utils.keyvaluecache": "^2.1.0",
+        "@apollo/utils.logger": "^2.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@apollo/usage-reporting-protobuf": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.1.tgz",
+      "integrity": "sha512-u40dIUePHaSKVshcedO7Wp+mPiZsaU6xjv9J+VyxpoU/zL6Jle+9zWeG98tr/+SZ0nZ4OXhrbb8SNr0rAPpIDA==",
+      "dependencies": {
+        "@apollo/protobufjs": "1.2.7"
+      }
+    },
+    "node_modules/@apollo/utils.createhash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.createhash/-/utils.createhash-2.0.1.tgz",
+      "integrity": "sha512-fQO4/ZOP8LcXWvMNhKiee+2KuKyqIcfHrICA+M4lj/h/Lh1H10ICcUtk6N/chnEo5HXu0yejg64wshdaiFitJg==",
+      "dependencies": {
+        "@apollo/utils.isnodelike": "^2.0.1",
+        "sha.js": "^2.4.11"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/utils.dropunuseddefinitions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.1.tgz",
+      "integrity": "sha512-EsPIBqsSt2BwDsv8Wu76LK5R1KtsVkNoO4b0M5aK0hx+dGg9xJXuqlr7Fo34Dl+y83jmzn+UvEW+t1/GP2melA==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.fetcher": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.fetcher/-/utils.fetcher-2.0.1.tgz",
+      "integrity": "sha512-jvvon885hEyWXd4H6zpWeN3tl88QcWnHp5gWF5OPF34uhvoR+DFqcNxs9vrRaBBSY3qda3Qe0bdud7tz2zGx1A==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/utils.isnodelike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.isnodelike/-/utils.isnodelike-2.0.1.tgz",
+      "integrity": "sha512-w41XyepR+jBEuVpoRM715N2ZD0xMD413UiJx8w5xnAZD2ZkSJnMJBoIzauK83kJpSgNuR6ywbV29jG9NmxjK0Q==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/utils.keyvaluecache": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.1.tgz",
+      "integrity": "sha512-qVo5PvUUMD8oB9oYvq4ViCjYAMWnZ5zZwEjNF37L2m1u528x5mueMlU+Cr1UinupCgdB78g+egA1G98rbJ03Vw==",
+      "dependencies": {
+        "@apollo/utils.logger": "^2.0.1",
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@apollo/utils.logger": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/utils.printwithreducedwhitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.1.tgz",
+      "integrity": "sha512-9M4LUXV/fQBh8vZWlLvb/HyyhjJ77/I5ZKu+NBWV/BmYGyRmoEP9EVAy7LCVoY3t8BDcyCAGfxJaLFCSuQkPUg==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.removealiases": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.removealiases/-/utils.removealiases-2.0.1.tgz",
+      "integrity": "sha512-0joRc2HBO4u594Op1nev+mUF6yRnxoUH64xw8x3bX7n8QBDYdeYgY4tF0vJReTy+zdn2xv6fMsquATSgC722FA==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.sortast": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.sortast/-/utils.sortast-2.0.1.tgz",
+      "integrity": "sha512-eciIavsWpJ09za1pn37wpsCGrQNXUhM0TktnZmHwO+Zy9O4fu/WdB4+5BvVhFiZYOXvfjzJUcc+hsIV8RUOtMw==",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.stripsensitiveliterals": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.1.tgz",
+      "integrity": "sha512-QJs7HtzXS/JIPMKWimFnUMK7VjkGQTzqD9bKD1h3iuPAqLsxd0mUNVbkYOPTsDhUKgcvUOfOqOJWYohAKMvcSA==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.usagereporting": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.usagereporting/-/utils.usagereporting-2.1.0.tgz",
+      "integrity": "sha512-LPSlBrn+S17oBy5eWkrRSGb98sWmnEzo3DPTZgp8IQc8sJe0prDgDuppGq4NeQlpoqEHz0hQeYHAOA0Z3aQsxQ==",
+      "dependencies": {
+        "@apollo/usage-reporting-protobuf": "^4.1.0",
+        "@apollo/utils.dropunuseddefinitions": "^2.0.1",
+        "@apollo/utils.printwithreducedwhitespace": "^2.0.1",
+        "@apollo/utils.removealiases": "2.0.1",
+        "@apollo/utils.sortast": "^2.0.1",
+        "@apollo/utils.stripsensitiveliterals": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/utils.withrequired": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.1.tgz",
+      "integrity": "sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -735,6 +979,52 @@
         "node": ">=12"
       }
     },
+    "node_modules/@graphql-tools/merge": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
+      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+      "dependencies": {
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema": {
+      "version": "9.0.19",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
+      "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+      "dependencies": {
+        "@graphql-tools/merge": "^8.4.1",
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/utils": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1068,6 +1358,11 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@josephg/resolvable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.1.tgz",
+      "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg=="
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -1195,6 +1490,60 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1297,7 +1646,6 @@
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -1307,7 +1655,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1331,7 +1678,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
       "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-      "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -1343,7 +1689,6 @@
       "version": "4.17.43",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz",
       "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1360,11 +1705,19 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/graphql": {
+      "version": "14.5.0",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.5.0.tgz",
+      "integrity": "sha512-MOkzsEp1Jk5bXuAsHsUi6BVv0zCO+7/2PTiZMXWDSsMXvNU6w/PLMQT2vHn8hy2i0JqojPz1Sz6rsFjHtsU0lA==",
+      "deprecated": "This is a stub types definition. graphql provides its own type definitions, so you do not need this installed.",
+      "dependencies": {
+        "graphql": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1409,6 +1762,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -1418,8 +1776,7 @@
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "node_modules/@types/mongoose": {
       "version": "5.11.97",
@@ -1435,28 +1792,33 @@
       "version": "20.11.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
       "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/qs": {
       "version": "6.9.11",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
-      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
-      "dev": true
+      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -1466,7 +1828,6 @@
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
       "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
-      "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/mime": "*",
@@ -1698,11 +2059,18 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2123,7 +2491,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2213,6 +2580,18 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -2306,7 +2685,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2650,7 +3028,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2865,6 +3242,14 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
+    },
+    "node_modules/graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4038,6 +4423,28 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4390,6 +4797,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
     },
     "node_modules/node-addon-api": {
       "version": "5.1.0",
@@ -4881,6 +5293,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -4995,6 +5415,18 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5513,6 +5945,11 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5562,8 +5999,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -5616,6 +6052,18 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -5654,6 +6102,14 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/value-or-promise": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -5675,6 +6131,14 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
   "author": "dresnite",
   "license": "UNLICENSED",
   "dependencies": {
+    "@apollo/server": "^4.10.0",
+    "@types/graphql": "^14.5.0",
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.6",
     "express": "^4.18.2",
+    "graphql": "^16.8.1",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.1.2",
     "validator": "^13.11.0"

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,11 +2,13 @@ import express from "express";
 import cookieParser from "cookie-parser";
 import "./utils/database";
 import userRouter from "./routes/user";
+import graphqlRouter from "./routes/graphql";
 
 const app = express();
 
 app.use(express.json());
 app.use(cookieParser());
 app.use(userRouter);
+app.use(graphqlRouter);
 
 export default app;

--- a/src/controllers/crawlingJob.ts
+++ b/src/controllers/crawlingJob.ts
@@ -1,6 +1,7 @@
 import { ObjectId } from "mongoose";
-import { createCrawlingJob, getChildrenCrawlingJobs, getCrawlingJobById, getParentCrawlingJob } from "../services/crawlingJob";
+import { createCrawlingJob, getChildrenCrawlingJobs, getCrawlingJobById, getParentCrawlingJob, validateAuth } from "../services/crawlingJob";
 import ICrawlingJob from "../interfaces/ICrawlingJob";
+import CustomContext from "../interfaces/CustomContext";
 
 export async function getCrawlingJob(_root: any, { id }: { id: string }) {
     return await getCrawlingJobById(id);
@@ -20,6 +21,7 @@ export async function getChildrenJobs(job: ICrawlingJob) {
     return await getChildrenCrawlingJobs(job._id!);
 }
 
-export async function createJob(_root: any, job: ICrawlingJob) {
+export async function createJob(_root: any, job: ICrawlingJob, context: CustomContext) {
+    validateAuth(context);
     return await createCrawlingJob(job);
 }

--- a/src/controllers/crawlingJob.ts
+++ b/src/controllers/crawlingJob.ts
@@ -1,0 +1,25 @@
+import { ObjectId } from "mongoose";
+import { createCrawlingJob, getChildrenCrawlingJobs, getCrawlingJobById, getParentCrawlingJob } from "../services/crawlingJob";
+import ICrawlingJob from "../interfaces/ICrawlingJob";
+
+export async function getCrawlingJob(_root: any, { id }: { id: string }) {
+    return await getCrawlingJobById(id);
+}
+
+export async function getParentJob(job: ICrawlingJob) {
+    if(job.parentJob) {
+        return await getParentCrawlingJob(
+            (job.parentJob as ObjectId).toString()
+        );
+    }
+
+    return null;
+}
+
+export async function getChildrenJobs(job: ICrawlingJob) {
+    return await getChildrenCrawlingJobs(job._id!);
+}
+
+export async function createJob(_root: any, job: ICrawlingJob) {
+    return await createCrawlingJob(job);
+}

--- a/src/controllers/crawlingJob.ts
+++ b/src/controllers/crawlingJob.ts
@@ -1,5 +1,5 @@
 import { ObjectId } from "mongoose";
-import { createCrawlingJob, getChildrenCrawlingJobs, getCrawlingJobById, getCrawlingJobsByOwnerId, getParentCrawlingJob, validateAuth } from "../services/crawlingJob";
+import { createCrawlingJob, getChildrenCrawlingJobs, getCrawlingJobById, getCrawlingJobsByOwnerId, getOriginalCrawlingJobsByOwnerId, getParentCrawlingJob, validateAuth } from "../services/crawlingJob";
 import ICrawlingJob from "../interfaces/ICrawlingJob";
 import CustomContext from "../interfaces/CustomContext";
 
@@ -9,6 +9,10 @@ export async function getCrawlingJob(_root: any, { id }: { id: string }) {
 
 export async function getCrawlingJobsByOwner(_root: any, { owner }: { owner: string }) {
     return await getCrawlingJobsByOwnerId(owner);
+}
+
+export async function getOriginalCrawlingJobsByOwner(_root: any, { owner }: { owner: string }) {
+    return await getOriginalCrawlingJobsByOwnerId(owner);
 }
 
 export async function getParentJob(job: ICrawlingJob) {

--- a/src/controllers/crawlingJob.ts
+++ b/src/controllers/crawlingJob.ts
@@ -1,10 +1,14 @@
 import { ObjectId } from "mongoose";
-import { createCrawlingJob, getChildrenCrawlingJobs, getCrawlingJobById, getParentCrawlingJob, validateAuth } from "../services/crawlingJob";
+import { createCrawlingJob, getChildrenCrawlingJobs, getCrawlingJobById, getCrawlingJobsByOwnerId, getParentCrawlingJob, validateAuth } from "../services/crawlingJob";
 import ICrawlingJob from "../interfaces/ICrawlingJob";
 import CustomContext from "../interfaces/CustomContext";
 
 export async function getCrawlingJob(_root: any, { id }: { id: string }) {
     return await getCrawlingJobById(id);
+}
+
+export async function getCrawlingJobsByOwner(_root: any, { owner }: { owner: string }) {
+    return await getCrawlingJobsByOwnerId(owner);
 }
 
 export async function getParentJob(job: ICrawlingJob) {

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,0 +1,7 @@
+const resolvers = {
+    Query: {
+        greeting: () => "Hello w"
+    }
+};
+
+export default resolvers;

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,6 +1,17 @@
+import { createJob, getChildrenJobs, getCrawlingJob, getParentJob } from "../controllers/crawlingJob";
+
 const resolvers = {
     Query: {
-        greeting: () => "Hello w"
+        crawlingJob: getCrawlingJob
+    },
+
+    CrawlingJob: {
+        parentJob: getParentJob,
+        childrenJobs: getChildrenJobs
+    },
+
+    Mutation: {
+        createCrawlingJob: createJob
     }
 };
 

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,8 +1,9 @@
-import { createJob, getChildrenJobs, getCrawlingJob, getParentJob } from "../controllers/crawlingJob";
+import { createJob, getChildrenJobs, getCrawlingJob, getCrawlingJobsByOwner, getParentJob } from "../controllers/crawlingJob";
 
 const resolvers = {
     Query: {
-        crawlingJob: getCrawlingJob
+        crawlingJob: getCrawlingJob,
+        crawlingJobsByOwner: getCrawlingJobsByOwner
     },
 
     CrawlingJob: {

--- a/src/graphql/resolvers.ts
+++ b/src/graphql/resolvers.ts
@@ -1,9 +1,10 @@
-import { createJob, getChildrenJobs, getCrawlingJob, getCrawlingJobsByOwner, getParentJob } from "../controllers/crawlingJob";
+import { createJob, getChildrenJobs, getCrawlingJob, getCrawlingJobsByOwner, getOriginalCrawlingJobsByOwner, getParentJob } from "../controllers/crawlingJob";
 
 const resolvers = {
     Query: {
         crawlingJob: getCrawlingJob,
-        crawlingJobsByOwner: getCrawlingJobsByOwner
+        crawlingJobsByOwner: getCrawlingJobsByOwner,
+        originalCrawlingJobsByOwner: getOriginalCrawlingJobsByOwner
     },
 
     CrawlingJob: {

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,0 +1,22 @@
+type Query {
+    crawlingJob(id: ID!): CrawlingJob
+}
+
+type Mutation {
+    createCrawlingJob(seed: String!, parent: ID): CrawlingJob
+}
+
+type CrawlingJob {
+    id: ID!
+    parentJob: CrawlingJob
+    seed: String!
+    status: CrawlingJobStatus!
+    linksFound: [String!]!
+    childrenJobs: [CrawlingJob!]!
+}
+
+enum CrawlingJobStatus {
+    STOPPED
+    WORKING
+    FINISHED
+}

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,5 +1,6 @@
 type Query {
     crawlingJob(id: ID!): CrawlingJob
+    crawlingJobsByOwner(owner: ID!): [CrawlingJob!]!
 }
 
 type Mutation {

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -3,10 +3,11 @@ type Query {
 }
 
 type Mutation {
-    createCrawlingJob(seed: String!, parent: ID): CrawlingJob
+    createCrawlingJob(owner: ID!, seed: String!, parent: ID): CrawlingJob
 }
 
 type CrawlingJob {
+    owner: ID!,
     id: ID!
     parentJob: CrawlingJob
     seed: String!

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1,6 +1,7 @@
 type Query {
     crawlingJob(id: ID!): CrawlingJob
     crawlingJobsByOwner(owner: ID!): [CrawlingJob!]!
+    originalCrawlingJobsByOwner(owner: ID!): [CrawlingJob!]!
 }
 
 type Mutation {

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -1,0 +1,5 @@
+export default `#graphql
+    type Query {
+        string: String
+    }
+`

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -1,5 +1,6 @@
-export default `#graphql
-    type Query {
-        string: String
-    }
-`
+import { readFileSync } from "fs";
+import path from "path";
+
+const schema = readFileSync(path.resolve(__dirname, "schema.graphql"), "utf8");
+
+export default schema;

--- a/src/graphql/server.ts
+++ b/src/graphql/server.ts
@@ -1,0 +1,3 @@
+const server: any = "hello";
+
+export default server;

--- a/src/graphql/server.ts
+++ b/src/graphql/server.ts
@@ -1,3 +1,15 @@
-const server: any = "hello";
+import { ApolloServer } from "@apollo/server";
+import schema from "./schema";
+import resolvers from "./resolvers";
+import { Router } from "express";
+import { expressMiddleware } from "@apollo/server/express4";
+
+const server: ApolloServer = new ApolloServer({typeDefs: schema, resolvers});
+
+export async function startServer(router: Router) {
+    await server.start();
+
+    router.use("/graphql", expressMiddleware(server));
+};
 
 export default server;

--- a/src/graphql/server.ts
+++ b/src/graphql/server.ts
@@ -1,15 +1,29 @@
-import { ApolloServer } from "@apollo/server";
+import { ApolloServer, ContextFunction } from "@apollo/server";
 import schema from "./schema";
 import resolvers from "./resolvers";
 import { Router } from "express";
-import { expressMiddleware } from "@apollo/server/express4";
+import { ExpressContextFunctionArgument, expressMiddleware } from "@apollo/server/express4";
+import AuthenticatedRequest from "../interfaces/AuthenticatedRequest";
+import CustomContext from "../interfaces/CustomContext";
 
-const server: ApolloServer = new ApolloServer({typeDefs: schema, resolvers});
+const server = new ApolloServer<CustomContext>({typeDefs: schema, resolvers});
+
+const getContext: ContextFunction<[ExpressContextFunctionArgument], CustomContext> = async ({ req }: ExpressContextFunctionArgument) => {
+    const request = req as AuthenticatedRequest;
+
+    if(request.user) {
+        return { user: request.user };
+    }
+
+    return {};
+}
 
 export async function startServer(router: Router) {
     await server.start();
 
-    router.use("/graphql", expressMiddleware(server));
+    router.use("/graphql", expressMiddleware(server, {
+        context: getContext
+    }));
 };
 
 export default server;

--- a/src/graphql/status.ts
+++ b/src/graphql/status.ts
@@ -1,0 +1,7 @@
+enum Status {
+    Stopped = "STOPPED",
+    Working = "WORKING",
+    Finished = "FINISHED"
+}
+
+export default Status;

--- a/src/interfaces/CrawlingJobDocument.ts
+++ b/src/interfaces/CrawlingJobDocument.ts
@@ -1,0 +1,5 @@
+import ICrawlingJob from "./ICrawlingJob";
+
+export default interface CrawlingJobDocument extends ICrawlingJob, Document {
+    
+}

--- a/src/interfaces/CustomContext.ts
+++ b/src/interfaces/CustomContext.ts
@@ -1,0 +1,5 @@
+import IUser from "./IUser";
+
+export default interface CustomContext {
+    user?: IUser;
+}

--- a/src/interfaces/ICrawlingJob.ts
+++ b/src/interfaces/ICrawlingJob.ts
@@ -1,0 +1,11 @@
+import { ObjectId } from "mongoose";
+import Status from "../graphql/status";
+
+export default interface ICrawlingJob {
+    _id: string | undefined,
+    parentJob: ICrawlingJob | ObjectId | null,
+    seed: string,
+    status: Status,
+    linksFound: string[], // had to make it linksfound instead of links because of a conflict with document
+    childrenJobs: string[] // not children because of a conflict with Document too
+}

--- a/src/interfaces/ICrawlingJob.ts
+++ b/src/interfaces/ICrawlingJob.ts
@@ -1,7 +1,9 @@
 import { ObjectId } from "mongoose";
 import Status from "../graphql/status";
+import IUser from "./IUser";
 
 export default interface ICrawlingJob {
+    owner: IUser | ObjectId,
     _id: string | undefined,
     parentJob: ICrawlingJob | ObjectId | null,
     seed: string,

--- a/src/interfaces/ICrawlingJob.ts
+++ b/src/interfaces/ICrawlingJob.ts
@@ -5,7 +5,7 @@ import IUser from "./IUser";
 export default interface ICrawlingJob {
     owner: IUser | ObjectId | string,
     _id: string | undefined,
-    parentJob: ICrawlingJob | ObjectId | null,
+    parentJob: ICrawlingJob | ObjectId | string | null,
     seed: string,
     status: Status,
     linksFound: string[], // had to make it linksfound instead of links because of a conflict with document

--- a/src/interfaces/ICrawlingJob.ts
+++ b/src/interfaces/ICrawlingJob.ts
@@ -3,7 +3,7 @@ import Status from "../graphql/status";
 import IUser from "./IUser";
 
 export default interface ICrawlingJob {
-    owner: IUser | ObjectId,
+    owner: IUser | ObjectId | string,
     _id: string | undefined,
     parentJob: ICrawlingJob | ObjectId | null,
     seed: string,

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,7 +1,7 @@
 import jwt, { JwtPayload } from "jsonwebtoken";
 import User from "../models/user";
 import { JWT_SECRET } from "../utils/config";
-import { Response, NextFunction, Request } from "express";
+import { Response, NextFunction } from "express";
 import AuthenticatedRequest from "../interfaces/AuthenticatedRequest";
 
 const DEFAULT_AUTH_ERROR = "Please authenticate";

--- a/src/models/crawlingJob.ts
+++ b/src/models/crawlingJob.ts
@@ -1,0 +1,29 @@
+import mongoose from "mongoose";
+import ICrawlingJob from "../interfaces/ICrawlingJob";
+
+const crawlingJobSchema = new mongoose.Schema<ICrawlingJob>({
+    parentJob: {
+        type: mongoose.Types.ObjectId,
+        ref: "CrawlingJob"
+    },
+    seed: {
+        type: String,
+        required: true
+    },
+    status: {
+        type: String,
+        required: true
+    },
+    linksFound: [{
+        type: String,
+        required: true
+    }],
+    childrenJobs: [{
+        type: mongoose.Types.ObjectId,
+        ref: "CrawlingJob"
+    }]
+});
+
+const CrawlingJob = mongoose.model("CrawlingJob", crawlingJobSchema);
+
+export default CrawlingJob;

--- a/src/models/crawlingJob.ts
+++ b/src/models/crawlingJob.ts
@@ -2,6 +2,11 @@ import mongoose from "mongoose";
 import ICrawlingJob from "../interfaces/ICrawlingJob";
 
 const crawlingJobSchema = new mongoose.Schema<ICrawlingJob>({
+    owner: {
+        type: mongoose.Types.ObjectId,
+        ref: "User",
+        required: true
+    },
     parentJob: {
         type: mongoose.Types.ObjectId,
         ref: "CrawlingJob"

--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -1,7 +1,9 @@
 import express from "express";
 import { startServer } from "../graphql/server";
+import auth from "../middleware/auth";
 
 const router = express.Router();
+router.use("/graphql", auth);
 
 startServer(router);
 

--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -1,0 +1,9 @@
+import express from "express";
+import { expressMiddleware } from "@apollo/server/express4";
+import server from "../graphql/server";
+
+const router = express.Router();
+
+router.use("/graphql", expressMiddleware(server));
+
+export default router;

--- a/src/routes/graphql.ts
+++ b/src/routes/graphql.ts
@@ -1,9 +1,8 @@
 import express from "express";
-import { expressMiddleware } from "@apollo/server/express4";
-import server from "../graphql/server";
+import { startServer } from "../graphql/server";
 
 const router = express.Router();
 
-router.use("/graphql", expressMiddleware(server));
+startServer(router);
 
 export default router;

--- a/src/services/crawlingJob.ts
+++ b/src/services/crawlingJob.ts
@@ -1,6 +1,8 @@
 import Status from "../graphql/status";
+import CustomContext from "../interfaces/CustomContext";
 import ICrawlingJob from "../interfaces/ICrawlingJob";
 import CrawlingJob from "../models/crawlingJob";
+import unauthorizedError from "../utils/unauthorizedError";
 
 export async function getCrawlingJobById(id: string): Promise<ICrawlingJob | null> {
     try {
@@ -47,5 +49,11 @@ export async function createCrawlingJob(job: ICrawlingJob): Promise<ICrawlingJob
         return newJob;
     } catch(e) {
         return null;
+    }
+}
+
+export async function validateAuth(context: CustomContext) {
+    if(!context.user) {
+        throw unauthorizedError("Not authorized to do this");
     }
 }

--- a/src/services/crawlingJob.ts
+++ b/src/services/crawlingJob.ts
@@ -28,6 +28,22 @@ export async function getCrawlingJobsByOwnerId(id: string): Promise<ICrawlingJob
     }
 }
 
+export async function getOriginalCrawlingJobsByOwnerId(id: string): Promise<ICrawlingJob[]> {
+    try {
+        const crawlingJob = await CrawlingJob.find({
+            owner: id,
+            $or: [
+              { parentJob: { $exists: false } }, 
+              { parentJob: null }
+            ]
+        });
+
+        return crawlingJob;
+    } catch {
+        return [];
+    }
+}
+
 export async function getParentCrawlingJob(parentId: string|null): Promise<ICrawlingJob | null> {
     if(parentId) {
         await getCrawlingJobById(parentId);

--- a/src/services/crawlingJob.ts
+++ b/src/services/crawlingJob.ts
@@ -1,0 +1,51 @@
+import Status from "../graphql/status";
+import ICrawlingJob from "../interfaces/ICrawlingJob";
+import CrawlingJob from "../models/crawlingJob";
+
+export async function getCrawlingJobById(id: string): Promise<ICrawlingJob | null> {
+    try {
+        const crawlingJob = await CrawlingJob.findById(id);
+
+        if(!crawlingJob) {
+            return null;
+        }
+
+        return crawlingJob;
+    } catch {
+        return null;
+    }
+}
+
+export async function getParentCrawlingJob(parentId: string|null): Promise<ICrawlingJob | null> {
+    if(parentId) {
+        await getCrawlingJobById(parentId);
+    }
+
+    return null;
+}
+
+export async function getChildrenCrawlingJobs(parentId: string): Promise<ICrawlingJob[]>{
+    try {
+        return await CrawlingJob.find({parentJob: parentId});
+    } catch {
+        return [];
+    }
+}
+
+export async function createCrawlingJob(job: ICrawlingJob): Promise<ICrawlingJob | null> {
+    try {
+        const newJob = new CrawlingJob({
+            parentJob: job.parentJob,
+            seed: job.seed,
+            status: Status.Working,
+            linksFound: job.linksFound,
+            childrenJobs: []
+        });
+        
+        await newJob.save();
+
+        return newJob;
+    } catch(e) {
+        return null;
+    }
+}

--- a/src/services/crawlingJob.ts
+++ b/src/services/crawlingJob.ts
@@ -18,6 +18,16 @@ export async function getCrawlingJobById(id: string): Promise<ICrawlingJob | nul
     }
 }
 
+export async function getCrawlingJobsByOwnerId(id: string): Promise<ICrawlingJob[]> {
+    try {
+        const crawlingJob = await CrawlingJob.find({ owner: id });
+
+        return crawlingJob;
+    } catch {
+        return [];
+    }
+}
+
 export async function getParentCrawlingJob(parentId: string|null): Promise<ICrawlingJob | null> {
     if(parentId) {
         await getCrawlingJobById(parentId);

--- a/src/services/crawlingJob.ts
+++ b/src/services/crawlingJob.ts
@@ -37,6 +37,7 @@ export async function getChildrenCrawlingJobs(parentId: string): Promise<ICrawli
 export async function createCrawlingJob(job: ICrawlingJob): Promise<ICrawlingJob | null> {
     try {
         const newJob = new CrawlingJob({
+            owner: job.owner,
             parentJob: job.parentJob,
             seed: job.seed,
             status: Status.Working,
@@ -52,7 +53,7 @@ export async function createCrawlingJob(job: ICrawlingJob): Promise<ICrawlingJob
     }
 }
 
-export async function validateAuth(context: CustomContext) {
+export const validateAuth = (context: CustomContext) => {
     if(!context.user) {
         throw unauthorizedError("Not authorized to do this");
     }

--- a/src/utils/unauthorizedError.ts
+++ b/src/utils/unauthorizedError.ts
@@ -1,0 +1,7 @@
+import { GraphQLError } from "graphql";
+
+export default function unauthorizedError(message: string): GraphQLError {
+    return new GraphQLError(message, {
+        extensions: { code: "UNAUTHORIZED_ERROR" }
+    });
+}

--- a/tests/fixtures/database.ts
+++ b/tests/fixtures/database.ts
@@ -3,6 +3,7 @@ import jwt from "jsonwebtoken";
 import { JWT_SECRET } from "../../src/utils/config";
 import mongoose from "mongoose";
 import IUser from "../../src/interfaces/IUser";
+import CrawlingJob from "../../src/models/crawlingJob";
 
 export const dummyUserId = new mongoose.Types.ObjectId();
 
@@ -18,6 +19,7 @@ export const dummyUser: IUser = {
 
 export async function prepareDatabase() {
     await User.deleteMany();
+    await CrawlingJob.deleteMany();
 
     await (new User({_id: dummyUserId, ...dummyUser})).save();
 }

--- a/tests/fixtures/database.ts
+++ b/tests/fixtures/database.ts
@@ -31,10 +31,23 @@ export const dummyCrawlingJob: ICrawlingJob = {
     childrenJobs: []
 };
 
+export const secondDummyCrawlingJobId = new mongoose.Types.ObjectId();
+
+export const secondDummyCrawlingJob: ICrawlingJob = {
+    owner: dummyUserId.toString(),
+    _id: dummyCrawlingJobId.toString(),
+    parentJob: dummyCrawlingJobId.toString(),
+    seed: "https://elpais.com",
+    status: Status.Working,
+    linksFound: [],
+    childrenJobs: []
+};
+
 export async function prepareDatabase() {
     await User.deleteMany();
     await CrawlingJob.deleteMany();
 
     await (new User({_id: dummyUserId, ...dummyUser})).save();
     await (new CrawlingJob(dummyCrawlingJob)).save();
+    await (new CrawlingJob(secondDummyCrawlingJob)).save();
 }

--- a/tests/fixtures/database.ts
+++ b/tests/fixtures/database.ts
@@ -4,6 +4,8 @@ import { JWT_SECRET } from "../../src/utils/config";
 import mongoose from "mongoose";
 import IUser from "../../src/interfaces/IUser";
 import CrawlingJob from "../../src/models/crawlingJob";
+import ICrawlingJob from "../../src/interfaces/ICrawlingJob";
+import Status from "../../src/graphql/status";
 
 export const dummyUserId = new mongoose.Types.ObjectId();
 
@@ -17,9 +19,22 @@ export const dummyUser: IUser = {
     ]
 };
 
+export const dummyCrawlingJobId = new mongoose.Types.ObjectId();
+
+export const dummyCrawlingJob: ICrawlingJob = {
+    owner: dummyUserId.toString(),
+    _id: dummyCrawlingJobId.toString(),
+    parentJob: null,
+    seed: "https://elpais.com",
+    status: Status.Working,
+    linksFound: [],
+    childrenJobs: []
+};
+
 export async function prepareDatabase() {
     await User.deleteMany();
     await CrawlingJob.deleteMany();
 
     await (new User({_id: dummyUserId, ...dummyUser})).save();
+    await (new CrawlingJob(dummyCrawlingJob)).save();
 }

--- a/tests/fixtures/database.ts
+++ b/tests/fixtures/database.ts
@@ -35,7 +35,7 @@ export const secondDummyCrawlingJobId = new mongoose.Types.ObjectId();
 
 export const secondDummyCrawlingJob: ICrawlingJob = {
     owner: dummyUserId.toString(),
-    _id: dummyCrawlingJobId.toString(),
+    _id: secondDummyCrawlingJobId.toString(),
     parentJob: dummyCrawlingJobId.toString(),
     seed: "https://elpais.com",
     status: Status.Working,

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -124,7 +124,7 @@ test("Should obtain original crawling jobs created by an user", async () => {
         })
         .expect(200);
 
-    expect(response.body.data.crawlingJobsByOwner[0]?.seed).toBe(dummyCrawlingJob.seed);
-    expect(response.body.data.crawlingJobsByOwner.length).toBe(1);
+    expect(response.body.data.originalCrawlingJobsByOwner[0]?.seed).toBe(dummyCrawlingJob.seed);
+    expect(response.body.data.originalCrawlingJobsByOwner.length).toBe(1);
 });
 

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -23,6 +23,14 @@ const jobsByOwnerQuery = `#graphql
     }
 `;
 
+const originalJobsByOwnerQuery = `#graphql
+    query JobsByOwner($owner: ID!) {
+        originalCrawlingJobsByOwner(owner: $owner) {
+            seed
+        }
+    }
+`;
+
 const createJobQuery = `#graphql
     mutation CreateCrawlingJob($owner: ID!, $seed: String!, $parent: ID) {
         createCrawlingJob(owner: $owner, seed: $seed, parent: $parent) {
@@ -100,7 +108,23 @@ test("Should obtain crawling jobs created by an user", async () => {
             }
         })
         .expect(200);
-        
+
     expect(response.body.data.crawlingJobsByOwner[0]?.seed).toBe(dummyCrawlingJob.seed);
+});
+
+test("Should obtain original crawling jobs created by an user", async () => {
+    const response = await request(app)
+        .post("/graphql")
+        .set("Cookie", `authToken=${dummyUser.tokens[0].token}`)
+        .send({
+            query: originalJobsByOwnerQuery,
+            variables: {
+                owner: dummyUserId
+            }
+        })
+        .expect(200);
+
+    expect(response.body.data.crawlingJobsByOwner[0]?.seed).toBe(dummyCrawlingJob.seed);
+    expect(response.body.data.crawlingJobsByOwner.length).toBe(1);
 });
 

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -100,7 +100,7 @@ test("Should obtain crawling jobs created by an user", async () => {
             }
         })
         .expect(200);
-    
-    expect(response.body.jobs[0]?.seed).toBe(dummyCrawlingJob.seed);
+        
+    expect(response.body.data.crawlingJobsByOwner[0]?.seed).toBe(dummyCrawlingJob.seed);
 });
 

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -18,7 +18,7 @@ const jobByIdQuery = `#graphql
 const jobsByOwnerQuery = `#graphql
     query JobsByOwner($owner: ID!) {
         crawlingJobsByOwner(owner: $owner) {
-            jobs
+            seed
         }
     }
 `;


### PR DESCRIPTION
## Description

This PR adds GraphQL support, exposes the `/graphql` route and prepares the schema structure that will feature the crawling jobs.

## Schema

There will be a type, `CrawlingJob` that wil be composed of:

- `owner`: The ID of the user that created the crawling job.
- `seed`: The URL that the job will parse, e.g. _https://elpais.com_ or _https://elpais.com/other_.
- `status`: Whether the crawling process has _stopped_, is still _working_ or has already _finished_.
- `found`: A list of the URLs that were found in this job, e.g. `[https://elcontinente.com, https://elplaneta.com]`.
- `parent`: If a CrawlingJob is created by another CrawlingJob, this property will be its ID, otherwise this will be null.

## Justification

GraphQL is better suited than a REST API for Crawling Jobs because it reduces overfetching and underfetching. For example, if a third-party or frontend needs to access a specific CrawlingJob and its children, GraphQL enables retrieval without unnecessary data from other child jobs.

Crawling jobs often involve a large number of children, making GraphQL a clear winner over a REST API. With GraphQL, clients can easily select only the data they need, making it a more efficient option.

## Tests

- `tests/jobs.test.ts`: Tests all of the queries and mutations related to the CrawlingJob type.